### PR TITLE
Fixed re-rendering causing position offset

### DIFF
--- a/module/improved-macro-editor.js
+++ b/module/improved-macro-editor.js
@@ -16,14 +16,16 @@ const windowSizes = {
 Hooks.on("renderMacroConfig", (app, html, data) => {
     const size = windowSizes[game.settings.get("improved-macro-editor", "window-size")];
 
-    app.setPosition({
-        width: size.width,
-        height: size.height
-    });
-    app.setPosition({
-        left: (window.innerWidth - size.width) / 2,
-        top: (window.innerHeight - size.height) / 2
-    });
+    if(!app.rendered){
+        app.setPosition({
+            width: size.width,
+            height: size.height
+        });
+        app.setPosition({
+            left: (window.innerWidth - size.width) / 2,
+            top: (window.innerHeight - size.height) / 2
+        });
+    }
 
     const textarea = html.find('textarea[name="command"]');
     const code = textarea.val();

--- a/module/improved-macro-editor.js
+++ b/module/improved-macro-editor.js
@@ -16,7 +16,7 @@ const windowSizes = {
 Hooks.on("renderMacroConfig", (app, html, data) => {
     const size = windowSizes[game.settings.get("improved-macro-editor", "window-size")];
 
-    if(!app.rendered){
+    if(!app._submitting){
         app.setPosition({
             width: size.width,
             height: size.height


### PR DESCRIPTION
In Foundry v11, clicking on the execute macro button re-renders the macro application, and this change prevents the position and size from resetting when that happens.